### PR TITLE
git repo monitoring, closes sown/tasks#77

### DIFF
--- a/checks/check_git
+++ b/checks/check_git
@@ -1,0 +1,21 @@
+#!/bin/bash
+if [ ! -f /etc/git-repos ]; then
+	echo "GIT no repos"
+	exit 0
+fi
+for repo in $(cat /etc/git-repos); do
+	if [ $(git -C $repo status --porcelain | wc -l) -ne 0 ]; then
+		echo "Repo $repo has uncommitted changes"
+		exit 1
+	fi
+	if [ $(git -C $repo log @{u}.. | wc -l) -ne 0 ]; then
+		echo "Repo $repo has unpushed changes"
+		exit 1
+	fi
+	if [ $(git -C $repo log ..@{u} | wc -l) -ne 0 ]; then
+		echo "Repo $repo is behind upstream"
+		exit 1
+	fi
+done
+echo "GIT check OK"
+exit 0

--- a/config/zones.d/sown/commands.conf
+++ b/config/zones.d/sown/commands.conf
@@ -23,6 +23,7 @@ const NRPECommands = [
 	"check_psu",
 	"check_zpool_health",
 	"check_zpool_usage",
+	"check_git",
 ]
 
 for (var nrpecommand in NRPECommands) {

--- a/config/zones.d/sown/services.conf
+++ b/config/zones.d/sown/services.conf
@@ -192,5 +192,5 @@ apply Service "ZPOOL-USAGE" {
 apply Service "GIT" {
 	import "frequent-service"
 	check_command = "check_git"
-	assign where host.name == "MONITOR"
+	assign where host.vars.role in ServerRoles
 }

--- a/config/zones.d/sown/services.conf
+++ b/config/zones.d/sown/services.conf
@@ -188,3 +188,9 @@ apply Service "ZPOOL-USAGE" {
 	check_command = "check_zpool_usage"
 	assign where "Backup Server" == host.vars.role
 }
+
+apply Service "GIT" {
+	import "frequent-service"
+	check_command = "check_git"
+	assign where host.name == "MONITOR"
+}


### PR DESCRIPTION
This will also need the submodule in ansible updating, to deploy the check script to everywhere

For now I've just manually rolled it out to MONITOR only

closes sown/tasks#77