### PR TITLE
Removes unused legacy check_disk_vms

### DIFF
--- a/config/zones.d/sown/commands.conf
+++ b/config/zones.d/sown/commands.conf
@@ -15,7 +15,6 @@ const NRPECommands = [
 	"check_users",
 	"check_reboot",
 	"check_packages",
-	"check_disk_vms",
 	"check_disks",
 	"check_debsums",
 	"check_raid",

--- a/config/zones.d/sown/services.conf
+++ b/config/zones.d/sown/services.conf
@@ -70,19 +70,6 @@ apply Service for (address => interface in host.vars.addresses){
 		}
 }
 
-
-object Service "DISK-VMS-B32-1" {
-	import "generic-service"
-	check_command = "check_disk_vms"
-	host_name = "VMS-B32-1"
-}
-
-object Service "DISK-VMS-B53-1" {
-        import "generic-service"
-        check_command = "check_disk_vms"
-        host_name = "VMS-B53-1"
-}
-
 apply Service "POWER" {
 	import "generic-service"
 	check_command = "check_psu"


### PR DESCRIPTION
These checks no longer exist on VMS servers so should be removed to avoid unknown responses on monitor2.